### PR TITLE
Add MeanThreshold module

### DIFF
--- a/demo/data/sklearn_data_poisson_processes.m
+++ b/demo/data/sklearn_data_poisson_processes.m
@@ -1,0 +1,22 @@
+function [X_train, X_test, y_train, y_test] = sklearn_data_poisson_processes()
+% Generate a data set containing a Poisson process in each feature
+
+%% PARAMETERS
+test_size = 1/3;
+num_times = 300;
+num_processes = 50;
+lambda_scale = 10;
+
+%% GENERATE
+% time-varying underlying rate is the ground-truth label
+lambdas = lambda_scale * rand(num_times, 1);
+
+% Each feature/process has a rate scaled from the underlying rate
+rate_scales = rand(1, num_processes);
+
+% Scale time-varying lambdas for each process
+rates = lambdas * rate_scales;
+events = poissrnd(rates);
+
+% Split datasets by time-points
+[X_train, X_test, y_train, y_test] = train_test_split(events,lambdas,test_size);

--- a/demo/demo_mean_threshold.m
+++ b/demo/demo_mean_threshold.m
@@ -1,0 +1,35 @@
+% Remove features using a variance threshold
+
+%%
+close all
+clear
+rng('default');
+rng(1); % for reproducibility
+
+%% Load data
+[X_train, X_test, y_train, y_test] = sklearn_data_poisson_processes();
+
+%% Train, ignoring low-rate measurements of y
+params = struct('threshold', 2);
+mt = MeanThreshold(params);
+ridge = Ridge;
+
+pipeline = make_pipeline(mt, ridge);
+pipeline.fit(X_train, y_train);
+
+%% Predict
+y_pred = pipeline.predict(X_test);
+score = r2_score(y_test, y_pred);
+fprintf('Regression score is %.2f\n',score);
+
+%% Log diagnostics
+fprintf('number of original features: %d\n', size(X_train, 2));
+fprintf('number of features used: %d\n', nnz(mt.get_support()));
+
+%% OUTPUT
+
+figure;
+scatter(y_pred, y_test);
+xlabel('predicted');
+ylabel('truth');
+title('Ridge regression with MeanThreshold demo')

--- a/lib/feature_selection/MeanThreshold.m
+++ b/lib/feature_selection/MeanThreshold.m
@@ -1,0 +1,40 @@
+classdef MeanThreshold < BaseEstimator & SelectorMixin
+    % Feature selector that removes all low-mean features.
+    % Useful for discarding low-rate Poisson features
+
+    properties (GetAccess = 'public', SetAccess = 'public')
+        % parameters
+        threshold = 0; % (float) features with a training-set mean lower than this threshold will be removed.
+    end
+    
+    properties (GetAccess = 'public', SetAccess = 'private')
+        % attributes
+        means; % (array, shape [n_features]) Means of individual features.
+    end
+    
+    methods
+        % constructor
+        function obj = MeanThreshold(params)
+            if nargin>0
+                obj.set_params(params)
+            end
+        end
+        
+        % Fit the model with X.
+        function fit(obj,X,~)
+            dim = 1;
+            obj.means = mean(X, dim);
+            
+            assert(~all(obj.means <= obj.threshold),...
+                   'No feature in X meets the mean threshold %f', obj.threshold);
+        end
+        
+    end
+    
+    methods (Access = 'protected')
+        % Return the feature selection mask
+        function mask = get_support_mask(obj)
+            mask = obj.means > obj.threshold;
+        end
+    end
+end


### PR DESCRIPTION
Useful when working with non-negative integer data like neural firing rates, where we may want to exclude minimally-active features